### PR TITLE
Respect NATIVE_LIBS_OUTPUT_DIR in Windows build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,14 +5,22 @@ project(tray LANGUAGES C CXX)
 # Define the C++ standard
 set(CMAKE_CXX_STANDARD 17)
 
+# Allow overriding the output base directory via environment variable
+# (used by CI to write artifacts to build/nativeLibs instead of src/commonMain/resources)
+if(DEFINED ENV{NATIVE_LIBS_OUTPUT_DIR})
+    set(BASE_OUTPUT_DIR "$ENV{NATIVE_LIBS_OUTPUT_DIR}")
+else()
+    set(BASE_OUTPUT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../src/commonMain/resources")
+endif()
+
 # Check target architecture
 if(CMAKE_GENERATOR_PLATFORM STREQUAL "x64" OR CMAKE_GENERATOR_PLATFORM STREQUAL "")
     set(TARGET_ARCH "x64")
-    set(OUTPUT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../src/commonMain/resources/win32-x86-64")
+    set(OUTPUT_DIR "${BASE_OUTPUT_DIR}/win32-x86-64")
     add_compile_options("/arch:AVX2")
 elseif(CMAKE_GENERATOR_PLATFORM STREQUAL "ARM64")
     set(TARGET_ARCH "ARM64")
-    set(OUTPUT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../src/commonMain/resources/win32-arm64")
+    set(OUTPUT_DIR "${BASE_OUTPUT_DIR}/win32-arm64")
     add_compile_options("/arch:arm64")
 else()
     message(FATAL_ERROR "Unsupported architecture: ${CMAKE_GENERATOR_PLATFORM}")


### PR DESCRIPTION
## Summary
- Read `NATIVE_LIBS_OUTPUT_DIR` from the environment in `CMakeLists.txt`
- When set (by CI), DLLs are written to `$NATIVE_LIBS_OUTPUT_DIR/win32-x86-64/` and `$NATIVE_LIBS_OUTPUT_DIR/win32-arm64/` instead of the default `../src/commonMain/resources/`
- Falls back to the previous default when the variable is not set (local development)
- Aligns the Windows build with the macOS and Linux builds which already honour this variable

Fixes the `publish-on-maven` CI workflow failing because the upload-artifact step looks for DLLs in `build/nativeLibs/` but the build writes to `src/commonMain/resources/`.